### PR TITLE
Add tool-free pulling weeds gig

### DIFF
--- a/src/data/jobs.json
+++ b/src/data/jobs.json
@@ -1,5 +1,15 @@
 [
   {
+    "id": "pull_weeds",
+    "name": "Pull Weeds",
+    "stage": "Laborer",
+    "durationH": 2,
+    "reqTools": [],
+    "materials": {},
+    "payout": 300,
+    "rep": 1
+  },
+  {
     "id": "yard_cleanup",
     "name": "Yard Cleanup",
     "stage": "Laborer",


### PR DESCRIPTION
## Summary
- add a Laborer-stage "Pull Weeds" gig with no tool requirements
- set its low-duration, low-payout stats so new players have an accessible first job

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d967be9cd0832f9de4732c4fbff75a