### PR TITLE
Ensure pull weeds gig is available in existing saves

### DIFF
--- a/src/data/jobs.json
+++ b/src/data/jobs.json
@@ -1,5 +1,15 @@
 [
   {
+    "id": "pull_weeds",
+    "name": "Pull Weeds",
+    "stage": "Laborer",
+    "durationH": 2,
+    "reqTools": [],
+    "materials": {},
+    "payout": 300,
+    "rep": 1
+  },
+  {
     "id": "yard_cleanup",
     "name": "Yard Cleanup",
     "stage": "Laborer",

--- a/src/logic/save.js
+++ b/src/logic/save.js
@@ -89,7 +89,7 @@ export const createInitialState = (permanentMods = {}) => {
 
 const mergeState = (loaded) => {
   const initial = createInitialState(loaded?.prestige?.permanentMods ?? {});
-  return {
+  const merged = {
     ...initial,
     ...loaded,
     resources: { ...initial.resources, ...loaded?.resources },
@@ -114,6 +114,7 @@ const mergeState = (loaded) => {
     ui: { ...initial.ui, ...loaded?.ui },
     lastSave: loaded?.lastSave ?? 0,
   };
+  return ensureJobQueue(merged);
 };
 
 export const loadGame = () => {


### PR DESCRIPTION
## Summary
- merge saved-game state with the initial queue to include all stage-appropriate gigs
- ensure the new Pull Weeds job is available even for players loading older saves without tools

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d967be9cd0832f9de4732c4fbff75a