### PR TITLE
Require targeting jobs to spend turns

### DIFF
--- a/src/data/jobs.json
+++ b/src/data/jobs.json
@@ -6,7 +6,7 @@
     "turnsRequired": 2,
     "reqTools": [],
     "materials": {},
-    "payout": 300,
+    "payout": 5,
     "rep": 1
   },
   {

--- a/src/logic/__tests__/tick.test.js
+++ b/src/logic/__tests__/tick.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createInitialState } from '../save.js';
-import { recalculateDerived, takeGig, buyTool, endTurn, endDay } from '../actions.js';
+import { recalculateDerived, takeGig, buyTool, workJob, endDay } from '../actions.js';
 
 const runTurns = (state, turns) => {
   let next = state;
@@ -9,7 +9,9 @@ const runTurns = (state, turns) => {
     if (next.turnsLeft <= 0) {
       next = endDay(next);
     } else {
-      next = endTurn(next);
+      const active = next.jobs.active[0];
+      if (!active) break;
+      next = workJob(next, active.id);
       remaining -= 1;
     }
   }

--- a/src/logic/actions.js
+++ b/src/logic/actions.js
@@ -239,6 +239,17 @@ export const endTurn = (state) => {
   return recalculateDerived(consumed);
 };
 
+export const workJob = (state, jobId) => {
+  if (state.turnsLeft <= 0) return state;
+  if (!jobId) return state;
+  const activeJob = state.jobs.active.find((job) => job.id === jobId);
+  if (!activeJob) return state;
+  const progressed = advanceTick(state, TURN_SECONDS, jobId);
+  if (progressed === state) return state;
+  const consumed = consumeTurn(progressed);
+  return recalculateDerived(consumed);
+};
+
 export const buyTool = (state, toolId) => {
   const tool = getTool(toolId);
   if (!tool) return state;

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -17,6 +17,7 @@ import {
   hireCrewMember,
   togglePolicy,
   endTurn,
+  workJob,
   endDay,
   promoteStage,
   bidJob,
@@ -94,6 +95,7 @@ const App = () => {
       hireCrewMember: wrapAction(hireCrewMember),
       togglePolicy: wrapAction(togglePolicy),
       endTurn: wrapAction(endTurn),
+      workJob: wrapAction(workJob),
       endDay: wrapAction(endDay),
       promoteStage: wrapAction(promoteStage),
       bidJob: wrapAction(bidJob),
@@ -226,7 +228,7 @@ const App = () => {
         return (
           <Dashboard
             state={state}
-            onEndTurn={actions.endTurn}
+            onEndTurn={null}
             onEndDay={actions.endDay}
             onPromote={milestoneReady ? actions.promoteStage : null}
             nextMilestone={nextMilestone}
@@ -242,6 +244,7 @@ const App = () => {
             jobs={availableJobs}
             onTakeGig={actions.takeGig}
             onBid={actions.bidJob}
+            onWorkJob={actions.workJob}
           />
         );
       case 'Tools':

--- a/src/ui/Tabs/Dashboard.jsx
+++ b/src/ui/Tabs/Dashboard.jsx
@@ -33,7 +33,9 @@ const Dashboard = ({
     { label: 'Reputation', value: resources.reputation.toFixed(0) },
     { label: 'Morale', value: resources.morale.toFixed(2) },
     { label: 'Permits', value: resources.permits.toFixed(1) },
+    { label: 'Turns Left', value: state.turnsLeft.toFixed(0) },
   ];
+  const showEndTurnButton = typeof onEndTurn === 'function';
 
   return (
     <div className="panel">
@@ -45,16 +47,30 @@ const Dashboard = ({
               <Stat key={stat.label} label={stat.label} value={stat.value} />
             ))}
           </div>
-          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem', flexWrap: 'wrap' }}>
-            <button
-              type="button"
-              className="primary"
-              onClick={onEndTurn}
-              aria-label="End Turn"
-              disabled={state.turnsLeft <= 0}
-            >
-              End Turn
-            </button>
+          <div
+            style={{
+              display: 'flex',
+              gap: '0.5rem',
+              marginTop: '1rem',
+              flexWrap: 'wrap',
+              alignItems: 'center',
+            }}
+          >
+            {showEndTurnButton ? (
+              <button
+                type="button"
+                className="primary"
+                onClick={onEndTurn}
+                aria-label="End Turn"
+                disabled={state.turnsLeft <= 0}
+              >
+                End Turn
+              </button>
+            ) : (
+              <span style={{ fontSize: '0.85rem' }}>
+                Work jobs from the Jobs tab to spend turns.
+              </span>
+            )}
             {state.turnsLeft <= 0 ? (
               <button type="button" className="secondary" onClick={onEndDay} aria-label="End Day">
                 End Day

--- a/src/ui/Tabs/Jobs.jsx
+++ b/src/ui/Tabs/Jobs.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ProgressBar from '../components/ProgressBar.jsx';
 import { STAGE_ORDER } from '../../logic/content.js';
 
-const Jobs = ({ state, jobs, onTakeGig, onBid }) => {
+const Jobs = ({ state, jobs, onTakeGig, onBid, onWorkJob }) => {
   const canBid = STAGE_ORDER.indexOf(state.stage) >= STAGE_ORDER.indexOf('Contractor');
   return (
     <div className="panel">
@@ -53,20 +53,49 @@ const Jobs = ({ state, jobs, onTakeGig, onBid }) => {
         </tbody>
       </table>
       <div className="panel" style={{ marginTop: '1rem' }}>
-        <h2>Active Jobs</h2>
+        <h2>Job Queue</h2>
+        <p style={{ fontSize: '0.85rem', marginBottom: '0.75rem' }}>
+          Turns remaining today: <strong>{state.turnsLeft}</strong>
+        </p>
         {state.jobs.active.length === 0 ? (
           <p>No active jobs in progress.</p>
         ) : (
           state.jobs.active.map((job) => {
             const totalTurns = job.turnsRequired ?? job.durationH ?? 1;
             const turnsDone = Math.min(totalTurns, job.progress ?? 0);
+            const turnsRemaining = Math.max(0, totalTurns - turnsDone);
+            const disabled = state.turnsLeft <= 0 || turnsRemaining <= 0;
             return (
-              <ProgressBar
+              <div
                 key={job.id}
-                value={turnsDone}
-                max={totalTurns}
-                label={`${job.name} · ${turnsDone.toFixed(1)}/${totalTurns} turns`}
-              />
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  gap: '0.75rem',
+                  alignItems: 'center',
+                  marginBottom: '0.75rem',
+                }}
+              >
+                <div style={{ flex: '1 1 220px', minWidth: '220px' }}>
+                  <ProgressBar
+                    value={turnsDone}
+                    max={totalTurns}
+                    label={`${job.name} · ${turnsDone.toFixed(1)}/${totalTurns} turns`}
+                  />
+                </div>
+                <div style={{ fontSize: '0.85rem', minWidth: '120px' }}>
+                  {turnsRemaining.toFixed(1)} turns remaining
+                </div>
+                <button
+                  type="button"
+                  className="primary"
+                  onClick={() => onWorkJob(job.id)}
+                  disabled={disabled}
+                  aria-label={`Work on ${job.name}`}
+                >
+                  Work Turn
+                </button>
+              </div>
             );
           })
         )}


### PR DESCRIPTION
## Summary
- drop the Pull Weeds payout to $5
- add a workJob action and targeted tick handling so only the selected job advances each turn
- refresh the Jobs queue and Dashboard UI to apply turns from accepted jobs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9743283d8832f83c4d5f97325a81c