### PR TITLE
Add reset option to start a new game

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -96,6 +96,14 @@ button.secondary {
   border-radius: 8px;
 }
 
+button.danger {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  border-radius: 8px;
+}
+
 button:disabled {
   opacity: 0.5;
   cursor: not-allowed;

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -116,6 +116,11 @@ const App = () => {
 
   const handleExport = useCallback(() => exportSave(stateRef.current), []);
 
+  const handleReset = useCallback(() => {
+    clearSave();
+    updateState(recalculateDerived(loadGame()));
+  }, [updateState]);
+
   const handleImport = useCallback(
     (raw) => {
       try {
@@ -234,6 +239,7 @@ const App = () => {
             nextMilestone={nextMilestone}
             onExport={handleExport}
             onImport={handleImport}
+            onReset={handleReset}
             devActions={devActions}
           />
         );

--- a/src/ui/Tabs/Dashboard.jsx
+++ b/src/ui/Tabs/Dashboard.jsx
@@ -10,6 +10,7 @@ const Dashboard = ({
   nextMilestone,
   onExport,
   onImport,
+  onReset,
   devActions,
 }) => {
   const [saveText, setSaveText] = useState('');
@@ -93,13 +94,35 @@ const Dashboard = ({
         </div>
         <div className="panel">
           <h2>Save Data</h2>
-          <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
+          <div
+            style={{
+              display: 'flex',
+              gap: '0.5rem',
+              marginBottom: '0.5rem',
+              flexWrap: 'wrap',
+            }}
+          >
             <button type="button" onClick={handleExport} className="secondary">
               Export Save
             </button>
             <button type="button" onClick={handleImport} className="secondary">
               Import Save
             </button>
+            {onReset ? (
+              <button
+                type="button"
+                onClick={() => {
+                  if (window.confirm('Reset and start a new game? This cannot be undone.')) {
+                    onReset();
+                    setSaveText('');
+                    setStatus('New game started.');
+                  }
+                }}
+                className="danger"
+              >
+                Reset Game
+              </button>
+            ) : null}
           </div>
           <textarea
             style={{ width: '100%', minHeight: '120px', background: 'rgba(15,23,42,0.8)', color: 'inherit' }}


### PR DESCRIPTION
## Summary
- add a reset handler in the app state manager to clear the current save and reload a fresh game
- expose a reset button on the dashboard save panel with confirmation messaging
- style the new reset control with a danger treatment for visibility

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d97b271e78832f84eb57bb3cf421f4