### PR TITLE
Add skill leveling system and job XP rewards

### DIFF
--- a/src/data/jobs.json
+++ b/src/data/jobs.json
@@ -7,7 +7,11 @@
     "reqTools": [],
     "materials": {},
     "payout": 5,
-    "rep": 1
+    "rep": 1,
+    "skillXp": {
+      "Laborer": 15,
+      "Landscape Specialist": 10
+    }
   },
   {
     "id": "yard_cleanup",
@@ -17,7 +21,12 @@
     "reqTools": ["work_boots"],
     "materials": { "fuel": 2 },
     "payout": 450,
-    "rep": 2
+    "rep": 2,
+    "skillXp": {
+      "Laborer": 25,
+      "Organizer": 15,
+      "Landscape Specialist": 15
+    }
   },
   {
     "id": "patch_paint",
@@ -27,7 +36,12 @@
     "reqTools": ["work_boots", "drill"],
     "materials": { "lumber": 1 },
     "payout": 620,
-    "rep": 3
+    "rep": 3,
+    "skillXp": {
+      "Painter": 35,
+      "Trim Carpenter": 20,
+      "Drywall Installer": 10
+    }
   },
   {
     "id": "small_deck",
@@ -37,7 +51,12 @@
     "reqTools": ["work_boots", "circular_saw", "ladder"],
     "materials": { "lumber": 8, "concrete": 2 },
     "payout": 2100,
-    "rep": 6
+    "rep": 6,
+    "skillXp": {
+      "Carpenter": 45,
+      "Trim Carpenter": 30,
+      "Concrete Finisher": 20
+    }
   },
   {
     "id": "driveway_pour",
@@ -47,7 +66,12 @@
     "reqTools": ["work_boots", "generator"],
     "materials": { "concrete": 10, "steel": 2 },
     "payout": 3200,
-    "rep": 8
+    "rep": 8,
+    "skillXp": {
+      "Concrete Finisher": 50,
+      "Equipment Operator": 35,
+      "Heavy Equipment Mechanic": 15
+    }
   },
   {
     "id": "office_ti",
@@ -57,7 +81,13 @@
     "reqTools": ["work_boots", "drill", "ladder", "generator"],
     "materials": { "lumber": 6, "steel": 4, "concrete": 4 },
     "payout": 5200,
-    "rep": 12
+    "rep": 12,
+    "skillXp": {
+      "Electrician": 40,
+      "Drywall Installer": 30,
+      "HVAC Technician": 25,
+      "Plumber": 25
+    }
   },
   {
     "id": "duplex_frame",
@@ -67,6 +97,13 @@
     "reqTools": ["work_boots", "circular_saw", "generator", "mini_crane"],
     "materials": { "lumber": 16, "steel": 6 },
     "payout": 8800,
-    "rep": 18
+    "rep": 18,
+    "skillXp": {
+      "Project Manager": 40,
+      "Site Superintendent": 40,
+      "Safety Coordinator": 30,
+      "Estimator": 30,
+      "Surveyor": 20
+    }
   }
 ]

--- a/src/logic/__tests__/tick.test.js
+++ b/src/logic/__tests__/tick.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createInitialState } from '../save.js';
 import { recalculateDerived, takeGig, buyTool, workJob, endDay } from '../actions.js';
+import { normalizeSkillState } from '../skills.js';
 
 const runTurns = (state, turns) => {
   let next = state;
@@ -30,5 +31,7 @@ describe('tick loop', () => {
     expect(completed.jobs.active.length).toBe(0);
     expect(completed.jobs.completed.some((j) => j.id === 'yard_cleanup')).toBe(true);
     expect(completed.resources.cash).toBeGreaterThan(state.resources.cash);
+    const skills = normalizeSkillState(completed.player.skills);
+    expect(skills.Laborer.xp).toBeGreaterThan(0);
   });
 });

--- a/src/logic/actions.js
+++ b/src/logic/actions.js
@@ -347,13 +347,12 @@ export const hireCrewMember = (state, name, skill) => {
   return next;
 };
 
-export const updatePlayerProfile = (state, name, skill) => {
+export const updatePlayerProfile = (state, name) => {
   const next = cloneState(state);
   const trimmedName = typeof name === 'string' ? name.trim() : '';
-  const normalizedSkill = CREW_SKILLS.includes(skill) ? skill : DEFAULT_CREW_SKILL;
   next.player = {
+    ...next.player,
     name: trimmedName.length > 0 ? trimmedName : DEFAULT_PLAYER_NAME,
-    skill: normalizedSkill,
   };
   return next;
 };

--- a/src/logic/save.js
+++ b/src/logic/save.js
@@ -1,6 +1,7 @@
 import { applyEffectBundle, deepCopy } from './math.js';
 import { content, BASE_TURNS_BY_STAGE, jobsForStage } from './content.js';
 import CREW_SKILLS from '../data/crewSkills.js';
+import { createDefaultSkillState, normalizeSkillState } from './skills.js';
 
 const STORAGE_KEY = 'constructor-career-clicker-save';
 const AUTOSAVE_INTERVAL_MS = 5000;
@@ -41,7 +42,7 @@ const baseState = {
   },
   player: {
     name: DEFAULT_PLAYER_NAME,
-    skill: DEFAULT_CREW_SKILL,
+    skills: createDefaultSkillState(),
   },
   truck: {
     condition: 1.0,
@@ -109,9 +110,12 @@ const normalizeCrewMembers = (members = []) =>
   });
 
 const normalizePlayer = (player = {}) => {
-  const name = typeof player?.name === 'string' && player.name.trim().length > 0 ? player.name.trim() : DEFAULT_PLAYER_NAME;
-  const skill = CREW_SKILLS.includes(player?.skill) ? player.skill : DEFAULT_CREW_SKILL;
-  return { name, skill };
+  const name =
+    typeof player?.name === 'string' && player.name.trim().length > 0
+      ? player.name.trim()
+      : DEFAULT_PLAYER_NAME;
+  const normalizedSkills = normalizeSkillState(player?.skills ?? {});
+  return { name, skills: normalizedSkills };
 };
 
 const mergeState = (loaded) => {

--- a/src/logic/skills.js
+++ b/src/logic/skills.js
@@ -1,0 +1,68 @@
+import CREW_SKILLS from '../data/crewSkills.js';
+
+export const SKILL_XP_PER_LEVEL = 100;
+
+export const levelForXp = (xp = 0) => {
+  const safeXp = Number.isFinite(xp) ? Math.max(0, xp) : 0;
+  return Math.floor(safeXp / SKILL_XP_PER_LEVEL) + 1;
+};
+
+export const xpForLevel = (level = 1) => {
+  const safeLevel = Number.isFinite(level) ? Math.max(1, Math.floor(level)) : 1;
+  return (safeLevel - 1) * SKILL_XP_PER_LEVEL;
+};
+
+export const createSkillEntry = (xp = 0) => {
+  const totalXp = Number.isFinite(xp) ? Math.max(0, Math.floor(xp)) : 0;
+  return {
+    xp: totalXp,
+    level: levelForXp(totalXp),
+  };
+};
+
+export const createDefaultSkillState = () =>
+  CREW_SKILLS.reduce((acc, skill) => {
+    acc[skill] = createSkillEntry(0);
+    return acc;
+  }, {});
+
+export const normalizeSkillState = (skills = {}) => {
+  const normalized = createDefaultSkillState();
+  if (skills && typeof skills === 'object') {
+    Object.entries(skills).forEach(([skill, value]) => {
+      if (!CREW_SKILLS.includes(skill)) return;
+      const xp = typeof value === 'number' ? value : Number(value?.xp ?? 0);
+      normalized[skill] = createSkillEntry(xp);
+    });
+  }
+  return normalized;
+};
+
+export const addSkillXp = (skills, xpAwards = {}) => {
+  const updated = normalizeSkillState(skills);
+  Object.entries(xpAwards).forEach(([skill, xp]) => {
+    if (!CREW_SKILLS.includes(skill)) return;
+    const delta = Number(xp);
+    if (!Number.isFinite(delta) || delta <= 0) return;
+    const current = updated[skill]?.xp ?? 0;
+    updated[skill] = createSkillEntry(current + delta);
+  });
+  return updated;
+};
+
+export const getSkillProgress = (entry) => {
+  const xp = Number.isFinite(entry?.xp) ? Math.max(0, entry.xp) : 0;
+  const level = entry?.level ?? levelForXp(xp);
+  const levelFloor = xpForLevel(level);
+  const nextLevel = level + 1;
+  const nextLevelFloor = xpForLevel(nextLevel);
+  const intoLevel = xp - levelFloor;
+  const needed = nextLevelFloor - levelFloor;
+  return {
+    xp,
+    level,
+    progressXp: intoLevel,
+    neededXp: needed,
+    remainingXp: Math.max(0, needed - intoLevel),
+  };
+};

--- a/src/logic/tick.js
+++ b/src/logic/tick.js
@@ -1,6 +1,7 @@
 import { deepCopy, clamp } from './math.js';
 import { getJob } from './content.js';
 import { getAutosaveInterval, saveGame } from './save.js';
+import { addSkillXp } from './skills.js';
 
 const TICK_RATE = 10;
 const MS_PER_TICK = 1000 / TICK_RATE;
@@ -58,6 +59,12 @@ export const advanceTick = (state, dtSeconds = 1 / TICK_RATE, targetJobId = null
       if (jobDef) {
         next.resources.cash += jobDef.payout;
         next.resources.reputation += jobDef.rep;
+        if (jobDef.skillXp) {
+          next.player = {
+            ...next.player,
+            skills: addSkillXp(next.player?.skills, jobDef.skillXp),
+          };
+        }
         ledger.push({
           id: `${job.id}-complete-${Date.now()}`,
           type: 'job-complete',


### PR DESCRIPTION
## Summary
- add a shared skill utility to normalize, level, and award specialization XP
- grant skill experience on job completion and surface progress in the dashboard
- update saves, player profile editing, and tests to cover the new behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d98f799d80832f872f27efc1f63bd7