### PR TITLE
Add foam mitosis simulation shaders

### DIFF
--- a/Assets/Scripts/Sim/MaterialIds.cs
+++ b/Assets/Scripts/Sim/MaterialIds.cs
@@ -1,0 +1,13 @@
+namespace Sim
+{
+    /// <summary>
+    /// IDs used by the simulation textures and compute shaders.
+    /// Keep in sync with the GPU palette and shader constants.
+    /// </summary>
+    public static class MaterialIds
+    {
+        public const uint AIR = 0u;
+        public const uint WATER = 1u;
+        public const uint FOAM = 2u;
+    }
+}

--- a/Assets/Scripts/Sim/SimBindings.cs
+++ b/Assets/Scripts/Sim/SimBindings.cs
@@ -1,0 +1,84 @@
+using UnityEngine;
+
+namespace Sim
+{
+    /// <summary>
+    /// Helper that uploads tweakable parameters to the compute shaders each frame.
+    /// This is a minimal stub so that the new foam parameters have a clearly defined
+    /// location even when the rest of the project is omitted in this kata repository.
+    /// </summary>
+    public class SimBindings : MonoBehaviour
+    {
+        [System.Serializable]
+        public struct FoamParams
+        {
+            public uint EnableFoamMitosis;
+            public float FoamSpawnBudgetPct;
+            public float FoamPSplit;
+            public int FoamCooldownFrames;
+            public int FoamLifetimeFrames;
+            public float FoamPopProb;
+            public float FoamMergeProb;
+            public uint FoamBudget;
+        }
+
+        public ComputeShader fluidPass;
+        public ComputeShader foamPass;
+
+        private FoamParams _cached;
+        private uint _frameIndex;
+
+        private static uint BoolToUInt(bool value) => value ? 1u : 0u;
+
+        private void LateUpdate()
+        {
+            _frameIndex++;
+            UpdateParams();
+        }
+
+        private void UpdateParams()
+        {
+            _cached.EnableFoamMitosis = BoolToUInt(Tweaks.EnableFoamMitosis);
+            _cached.FoamSpawnBudgetPct = Tweaks.FoamSpawnBudgetPct;
+            _cached.FoamPSplit = Tweaks.FoamPSplit;
+            _cached.FoamCooldownFrames = Tweaks.FoamCooldownFrames;
+            _cached.FoamLifetimeFrames = Tweaks.FoamLifetimeFrames;
+            _cached.FoamPopProb = Tweaks.FoamPopProb;
+            _cached.FoamMergeProb = Tweaks.FoamMergeProb;
+        }
+
+        /// <summary>
+        /// Called by the simulation loop to bind the parameters and per-frame budget to the shaders.
+        /// </summary>
+        public void BindFoamParams(uint foamBudget)
+        {
+            _cached.FoamBudget = foamBudget;
+
+            if (fluidPass != null)
+            {
+                fluidPass.SetBool("g_EnableFoamMitosis", Tweaks.EnableFoamMitosis);
+                fluidPass.SetFloat("g_FoamSpawnBudgetPct", Tweaks.FoamSpawnBudgetPct);
+                fluidPass.SetFloat("g_FoamPSplit", Tweaks.FoamPSplit);
+                fluidPass.SetInt("g_FoamCooldownFrames", Tweaks.FoamCooldownFrames);
+                fluidPass.SetInt("g_FoamLifetimeFrames", Tweaks.FoamLifetimeFrames);
+                fluidPass.SetFloat("g_FoamPopProb", Tweaks.FoamPopProb);
+                fluidPass.SetFloat("g_FoamMergeProb", Tweaks.FoamMergeProb);
+                fluidPass.SetInt("g_FrameIndex", unchecked((int)_frameIndex));
+                fluidPass.SetInt("g_FoamBudget", unchecked((int)foamBudget));
+            }
+
+            if (foamPass != null)
+            {
+                foamPass.SetBool("g_EnableFoamMitosis", Tweaks.EnableFoamMitosis);
+                foamPass.SetFloat("g_FoamSpawnBudgetPct", Tweaks.FoamSpawnBudgetPct);
+                foamPass.SetFloat("g_FoamPSplit", Tweaks.FoamPSplit);
+                foamPass.SetInt("g_FoamCooldownFrames", Tweaks.FoamCooldownFrames);
+                foamPass.SetInt("g_FoamLifetimeFrames", Tweaks.FoamLifetimeFrames);
+                foamPass.SetFloat("g_FoamPopProb", Tweaks.FoamPopProb);
+                foamPass.SetFloat("g_FoamMergeProb", Tweaks.FoamMergeProb);
+                foamPass.SetInt("g_FrameIndex", unchecked((int)_frameIndex));
+                foamPass.SetInt("g_FoamBudget", unchecked((int)foamBudget));
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Sim/Tweaks.cs
+++ b/Assets/Scripts/Sim/Tweaks.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+namespace Sim
+{
+    /// <summary>
+    /// Runtime tweakable parameters for the fluid/foam simulation. These are usually hot-reloaded
+    /// via the inspector or debug UI so we keep them as <see cref="ScriptableObject"/> friendly
+    /// static fields.
+    /// </summary>
+    public static class Tweaks
+    {
+        [Header("Foam Mitosis")]
+        [Tooltip("Enable spawning of foam along the air-water interface.")]
+        public static bool EnableFoamMitosis = true;
+
+        [Tooltip("Fraction of the current water mass allowed to duplicate into foam each tick.")]
+        [Range(0f, 0.05f)]
+        public static float FoamSpawnBudgetPct = 0.003f;
+
+        [Tooltip("Per-cell probability that an eligible water cell attempts to split into foam.")]
+        [Range(0f, 1f)]
+        public static float FoamPSplit = 0.03f;
+
+        [Tooltip("Frames before the same water cell can spawn foam again.")]
+        [Range(0, 255)]
+        public static int FoamCooldownFrames = 20;
+
+        [Tooltip("Lifetime in frames before foam starts popping with FoamPopProb.")]
+        [Range(1, 255)]
+        public static int FoamLifetimeFrames = 60;
+
+        [Tooltip("Chance per frame that foam disappears once it reaches the lifetime threshold.")]
+        [Range(0f, 1f)]
+        public static float FoamPopProb = 0.12f;
+
+        [Tooltip("Chance per frame that foam collapses back into water when directly supported by it.")]
+        [Range(0f, 1f)]
+        public static float FoamMergeProb = 0.05f;
+    }
+}

--- a/Assets/Shaders/Compute/CommonShared.hlsl
+++ b/Assets/Shaders/Compute/CommonShared.hlsl
@@ -1,0 +1,176 @@
+#ifndef COMMON_SHARED_INCLUDED
+#define COMMON_SHARED_INCLUDED
+
+static const int2 kCardinals[4] = {
+    int2(0, 1),
+    int2(1, 0),
+    int2(0, -1),
+    int2(-1, 0)
+};
+
+#define MATERIAL_AIR   0u
+#define MATERIAL_WATER 1u
+#define MATERIAL_FOAM  2u
+
+cbuffer SimParams : register(b0)
+{
+    uint2 g_GridSize;          // xy resolution
+    uint  g_FrameIndex;        // current frame counter
+    uint  g_EnableFoamMitosis; // bool flag packed as uint
+    float g_FoamSpawnBudgetPct;
+    float g_FoamPSplit;
+    uint  g_FoamCooldownFrames;
+    uint  g_FoamLifetimeFrames;
+    float g_FoamPopProb;
+    float g_FoamMergeProb;
+}
+
+Texture2D<uint>      GridRead   : register(t0);
+RWTexture2D<uint>    GridWrite  : register(u0);
+Texture2D<uint>      AuxRead    : register(t1);
+RWTexture2D<uint>    AuxWrite   : register(u1);
+RWByteAddressBuffer  FoamBudget : register(u2);
+
+// Packed aux layout: [31:16] = age, [15:0] = cooldown.
+static const uint AUX_AGE_SHIFT = 16u;
+static const uint AUX_AGE_MASK  = 0xFFFF0000u;
+static const uint AUX_CD_MASK   = 0x0000FFFFu;
+
+bool InBounds(int2 p)
+{
+    return all(p >= 0) && p.x < g_GridSize.x && p.y < g_GridSize.y;
+}
+
+uint ReadIdR(uint2 p)
+{
+    return GridRead.Load(int3(p, 0));
+}
+
+uint ReadIdW(uint2 p)
+{
+    return GridWrite[p];
+}
+
+void WriteIdW(uint2 p, uint id)
+{
+    GridWrite[p] = id;
+}
+
+uint ReadAuxR(uint2 p)
+{
+    return AuxRead.Load(int3(p, 0));
+}
+
+uint ReadAuxW(uint2 p)
+{
+    return AuxWrite[p];
+}
+
+void WriteAuxW(uint2 p, uint value)
+{
+    AuxWrite[p] = value;
+}
+
+uint GetCooldownR(uint2 p)
+{
+    return ReadAuxR(p) & AUX_CD_MASK;
+}
+
+uint GetCooldownW(uint2 p)
+{
+    return ReadAuxW(p) & AUX_CD_MASK;
+}
+
+void SetCooldownW(uint2 p, uint cooldown)
+{
+    uint current = ReadAuxW(p);
+    uint ageBits = current & AUX_AGE_MASK;
+    uint packed = ageBits | (cooldown & AUX_CD_MASK);
+    WriteAuxW(p, packed);
+}
+
+uint GetAgeR(uint2 p)
+{
+    return ReadAuxR(p) >> AUX_AGE_SHIFT;
+}
+
+uint GetAgeW(uint2 p)
+{
+    return ReadAuxW(p) >> AUX_AGE_SHIFT;
+}
+
+void SetAgeW(uint2 p, uint age)
+{
+    age = min(age, 0xFFFFu);
+    uint current = ReadAuxW(p);
+    uint cooldownBits = current & AUX_CD_MASK;
+    uint packed = (age << AUX_AGE_SHIFT) | cooldownBits;
+    WriteAuxW(p, packed);
+}
+
+void CopyThrough(uint2 p)
+{
+    WriteIdW(p, ReadIdR(p));
+    WriteAuxW(p, ReadAuxR(p));
+}
+
+uint Hash3(uint x, uint y, uint z)
+{
+    uint3 v = uint3(x, y, z);
+    v ^= v.yzx * 0x9E3779B1u;
+    v ^= v.zxy * 0x7F4A7C15u;
+    v ^= v.xzy * 0x94D049BBu;
+    uint n = v.x ^ v.y ^ v.z;
+    n *= 0x7FEB352Du;
+    n ^= n >> 15;
+    n *= 0x846CA68Bu;
+    n ^= n >> 16;
+    return n;
+}
+
+float Rand01(uint2 p, uint seed)
+{
+    uint h = Hash3(p.x, p.y, seed);
+    return (h & 0x00FFFFFFu) / 16777216.0f;
+}
+
+bool IsInterface(uint2 p)
+{
+    if (ReadIdR(p) != MATERIAL_WATER)
+        return false;
+
+    [unroll]
+    for (int i = 0; i < 4; ++i)
+    {
+        int2 q = int2(p) + kCardinals[i];
+        if (!InBounds(q))
+            continue;
+        if (ReadIdR(uint2(q)) == MATERIAL_AIR)
+            return true;
+    }
+
+    return false;
+}
+
+bool TryConsumeFoamBudget()
+{
+    // Attempt a bounded CAS loop to avoid runaway contention.
+    [loop]
+    for (uint i = 0u; i < 8u; ++i)
+    {
+        uint current;
+        FoamBudget.InterlockedAdd(0, 0, current);
+        if ((int)current <= 0)
+            return false;
+
+        uint expected = current;
+        uint original;
+        FoamBudget.InterlockedCompareExchange(0, expected, current - 1u, original);
+        if (original == expected)
+            return true;
+    }
+
+    return false;
+}
+
+#endif // COMMON_SHARED_INCLUDED

--- a/Assets/Shaders/Compute/Pass.Fluid.compute
+++ b/Assets/Shaders/Compute/Pass.Fluid.compute
@@ -1,0 +1,74 @@
+#include "CommonShared.hlsl"
+
+[numthreads(8, 8, 1)]
+void CSMain(uint3 dispatchId : SV_DispatchThreadID)
+{
+    uint2 p = dispatchId.xy;
+    if (!InBounds(int2(p)))
+        return;
+
+    uint id = ReadIdR(p);
+
+    if (id != MATERIAL_WATER)
+    {
+        CopyThrough(p);
+        return;
+    }
+
+    uint cooldown = GetCooldownR(p);
+    if (cooldown > 0)
+    {
+        cooldown -= 1u;
+    }
+
+    WriteIdW(p, MATERIAL_WATER);
+    WriteAuxW(p, ReadAuxR(p));
+
+    bool spawnedFoam = false;
+
+    if (g_EnableFoamMitosis != 0u && cooldown == 0u && IsInterface(p))
+    {
+        float splitRng = Rand01(p, g_FrameIndex);
+        if (splitRng < g_FoamPSplit)
+        {
+            int2 offsets[3] = {
+                int2(0, 1),
+                int2(-1, 0),
+                int2(1, 0)
+            };
+
+            int picked = -1;
+            [unroll]
+            for (int i = 0; i < 3; ++i)
+            {
+                int2 q = int2(p) + offsets[i];
+                if (!InBounds(q))
+                    continue;
+
+                uint2 uq = uint2(q);
+                if (ReadIdR(uq) == MATERIAL_AIR && ReadIdW(uq) == MATERIAL_AIR)
+                {
+                    picked = i;
+                    break;
+                }
+            }
+
+            if (picked >= 0 && TryConsumeFoamBudget())
+            {
+                uint2 dst = p + uint2(offsets[picked]);
+                WriteIdW(dst, MATERIAL_FOAM);
+                WriteAuxW(dst, 0u);
+                SetAgeW(dst, 0u);
+                SetCooldownW(p, g_FoamCooldownFrames);
+                SetAgeW(p, 0u);
+                spawnedFoam = true;
+            }
+        }
+    }
+
+    if (!spawnedFoam)
+    {
+        SetCooldownW(p, cooldown);
+        SetAgeW(p, 0u);
+    }
+}

--- a/Assets/Shaders/Compute/Pass.Foam.compute
+++ b/Assets/Shaders/Compute/Pass.Foam.compute
@@ -1,0 +1,71 @@
+#include "CommonShared.hlsl"
+
+[numthreads(8, 8, 1)]
+void CSMain(uint3 dispatchId : SV_DispatchThreadID)
+{
+    uint2 p = dispatchId.xy;
+    if (!InBounds(int2(p)))
+        return;
+
+    uint id = ReadIdR(p);
+    if (id != MATERIAL_FOAM)
+    {
+        CopyThrough(p);
+        return;
+    }
+
+    WriteAuxW(p, ReadAuxR(p));
+
+    uint age = min(GetAgeR(p) + 1u, 0xFFFFu);
+
+    int2 below = int2(p) + int2(0, -1);
+    if (InBounds(below) && ReadIdR(uint2(below)) == MATERIAL_WATER)
+    {
+        if (Rand01(p, g_FrameIndex ^ 0x51633u) < g_FoamMergeProb)
+        {
+            WriteIdW(p, MATERIAL_WATER);
+            SetAgeW(p, 0u);
+            SetCooldownW(p, 0u);
+            return;
+        }
+    }
+
+    if (age >= g_FoamLifetimeFrames && Rand01(p, g_FrameIndex ^ 0x9E3779B9u) < g_FoamPopProb)
+    {
+        WriteIdW(p, MATERIAL_AIR);
+        SetAgeW(p, 0u);
+        SetCooldownW(p, 0u);
+        return;
+    }
+
+    int2 lateral = Rand01(p, g_FrameIndex ^ 0x7F4A7C15u) < 0.5f ? int2(-1, 0) : int2(1, 0);
+    int2 offsets[3] = { int2(0, 1), lateral, int2(0, 0) };
+
+    uint2 dst = p;
+    [unroll]
+    for (int i = 0; i < 2; ++i)
+    {
+        int2 cand = int2(p) + offsets[i];
+        if (!InBounds(cand))
+            continue;
+
+        uint2 uc = uint2(cand);
+        if (ReadIdR(uc) == MATERIAL_AIR && ReadIdW(uc) == MATERIAL_AIR)
+        {
+            dst = uc;
+            break;
+        }
+    }
+
+    WriteIdW(dst, MATERIAL_FOAM);
+    WriteAuxW(dst, 0u);
+    SetAgeW(dst, age);
+    SetCooldownW(dst, 0u);
+
+    if (dst.x != p.x || dst.y != p.y)
+    {
+        WriteIdW(p, MATERIAL_AIR);
+        SetAgeW(p, 0u);
+        SetCooldownW(p, 0u);
+    }
+}

--- a/Assets/Shaders/Present/Palette.hlsl
+++ b/Assets/Shaders/Present/Palette.hlsl
@@ -1,0 +1,23 @@
+#ifndef PALETTE_INCLUDED
+#define PALETTE_INCLUDED
+
+#define MATERIAL_AIR   0u
+#define MATERIAL_WATER 1u
+#define MATERIAL_FOAM  2u
+
+float3 PaletteLookup(uint id)
+{
+    const float3 water = float3(0.22, 0.45, 0.95);
+    const float3 foam = lerp(water, float3(1.0, 1.0, 1.0), 0.35);
+
+    if (id == MATERIAL_AIR)
+        return float3(0.0, 0.0, 0.0);
+    if (id == MATERIAL_WATER)
+        return water;
+    if (id == MATERIAL_FOAM)
+        return foam;
+
+    return float3(1.0, 0.0, 1.0);
+}
+
+#endif // PALETTE_INCLUDED


### PR DESCRIPTION
## Summary
- add tweakable foam mitosis parameters and bindings for the simulation
- introduce foam material ID and compute shader helpers for interface detection and budgeting
- implement fluid and foam compute passes plus palette entry for visualizing foam

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d99ccfe6f0832f83ea9f0a6ac91604